### PR TITLE
Fix Unicode special characters

### DIFF
--- a/progs/arm_ada_lang_io.adb
+++ b/progs/arm_ada_lang_io.adb
@@ -776,6 +776,7 @@ package body ARM_Ada_Lang_IO is
    begin
       Detail.Trace (Self, "Unicode_Character");
       Detail.Trace (Self, "Char_Code: " & Char_Code);
+      Detail.Append (Self, "&#" & Char_Code(2..Char_Code'Length) & ';');
    end Unicode_Character;
 
    -- Marks the end of a hanging item. Call only once per paragraph.


### PR DESCRIPTION
This tries to fix cases of @unicode command. It should work in Docusaurus markdown as in HTML.